### PR TITLE
post processing scripts

### DIFF
--- a/src/modular/URDF_writer.py
+++ b/src/modular/URDF_writer.py
@@ -4073,13 +4073,17 @@ class UrdfWriter:
 
         for post_processing_script in self.resource_finder.cfg['post_processing_scripts']:
             try:
-                script_path = self.resource_finder.get_expanded_path(['post_processing_scripts', post_processing_script])
+                script_path = self.resource_finder.get_expanded_path(['post_processing_scripts', post_processing_script, 'file'])
+                required = self.resource_finder.nested_access(['post_processing_scripts', post_processing_script, 'required'])
                 self.info_print(f"Running post processing script {post_processing_script}: {script_path}")
                 output = subprocess.check_output([script_path, "--destination-folder", deploy_dir, "--package-name", robot_name])
             except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError) as e:
-                self.error_print(e)
-                self.error_print(f"Skipping post processing script {post_processing_script}")
-                pass
+                if required:
+                    raise(e)
+                else:
+                    self.error_print(e)
+                    self.error_print(f"Skipping post processing script {post_processing_script}")
+                    pass
 
         return robot_name
 

--- a/src/modular/URDF_writer.py
+++ b/src/modular/URDF_writer.py
@@ -1095,9 +1095,8 @@ class UrdfWriter:
 
         self.config_file = config_file
 
-        self.resources_paths = [['resources_path'], ['external_resources', 'concert_resources_path'], ['external_resources', 'fhi_resources_path']]
         self.resource_finder = ResourceFinder(self.config_file)
-        self.modular_resources_manager = ModularResourcesManager(self.resource_finder, self.resources_paths)
+        self.modular_resources_manager = ModularResourcesManager(self.resource_finder)
 
         self.collision_elements = []
 
@@ -1648,7 +1647,7 @@ class UrdfWriter:
             self.n_cubes += 1
 
             slavecube = None
-            for resource_path in self.resources_paths:
+            for resource_path in self.resource_finder.resources_paths:
                 filename = self.resource_finder.get_filename('yaml/master_cube.yaml', resource_path)
                 template_name = self.resource_finder.get_filename('yaml/template.yaml', ['resources_path'])
 
@@ -1809,7 +1808,7 @@ class UrdfWriter:
             # self.T_con = self.mastercube.geometry.connector_length))
 
             mastercube = None
-            for resource_path in self.resources_paths:
+            for resource_path in self.resource_finder.resources_paths:
                 filename = self.resource_finder.get_filename('yaml/master_cube.yaml', resource_path)
                 template_name = self.resource_finder.get_filename('yaml/template.yaml', ['resources_path'])
 
@@ -1976,7 +1975,7 @@ class UrdfWriter:
         name = 'mobile_base' #  _' + str(len(self.listofhubs))
 
         mobilebase = None
-        for resource_path in self.resources_paths:
+        for resource_path in self.resource_finder.resources_paths:
             filename = self.resource_finder.get_filename('json/concert/mobile_platform_concert.json', resource_path)
             template_name = self.resource_finder.get_filename('yaml/template.yaml', ['resources_path'])
 
@@ -2179,7 +2178,7 @@ class UrdfWriter:
 
         new_socket = None
         # Generate the path to the required YAML file
-        for resource_path in self.resources_paths:
+        for resource_path in self.resource_finder.resources_paths:
             module_name = self.resource_finder.get_filename('yaml/'+filename, resource_path)
             template_name = self.resource_finder.get_filename('yaml/template.yaml', ['resources_path'])
 
@@ -2538,7 +2537,7 @@ class UrdfWriter:
 
         new_module = None
         # Generate the path and access the required YAML file
-        for resource_path in self.resources_paths:
+        for resource_path in self.resource_finder.resources_paths:
             template_name = self.resource_finder.get_filename('yaml/template.yaml', ['resources_path'])
             try:
                 if filename.lower().endswith(('.yaml', '.yml')):

--- a/src/modular/URDF_writer.py
+++ b/src/modular/URDF_writer.py
@@ -4053,14 +4053,16 @@ class UrdfWriter:
     def deploy_robot(self, robot_name='modularbot', deploy_dir=None):
         script = self.resource_finder.get_filename('deploy.sh', ['data_path'])
 
-        if deploy_dir is None:
-            deploy_dir = os.path.expanduser(self.resource_finder.cfg['deploy_dir'])
-            deploy_dir = os.path.expandvars(deploy_dir)
-
-        if self.verbose:
-            output = subprocess.check_output([script, robot_name, "--destination-folder", deploy_dir, "-v"])
-        else:
-            output = subprocess.check_output([script, robot_name, "--destination-folder", deploy_dir])
+        try:
+            if deploy_dir is None:
+                deploy_dir = self.resource_finder.get_expanded_path(['deploy_dir'])
+            if self.verbose:
+                output = subprocess.check_output([script, robot_name, "--destination-folder", deploy_dir, "-v"])
+            else:
+                output = subprocess.check_output([script, robot_name, "--destination-folder", deploy_dir])
+        except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError) as e:
+            self.error_print(f"An error occurred when executing deploy script: {script}. Aborting.")
+            raise e
 
         self.info_print(str(output, 'utf-8', 'ignore'))
 
@@ -4070,21 +4072,14 @@ class UrdfWriter:
                 self.add_connectors(hub_module)
 
         for post_processing_script in self.resource_finder.cfg['post_processing_scripts']:
-            post_processing_script = os.path.expanduser(post_processing_script)
-            post_processing_script = os.path.expandvars(post_processing_script)
-            import re   
-            def substitute_function(match):
-                package_name = re.search(r"\$\(rospack find ([^\)]+)\)", match.group()).group(1)
-                return (
-                    subprocess.check_output(
-                        f"rospack find {package_name}".split(), stderr=subprocess.DEVNULL
-                    )
-                    .decode("utf-8")
-                    .rstrip()
-                )
-            post_processing_script = re.sub(r"\$\(rospack find [^\)]+\)", substitute_function, post_processing_script)
-            print(f"Running post processing script {post_processing_script}")
-            output = subprocess.check_output([post_processing_script, "--destination-folder", deploy_dir, "--package-name", robot_name])
+            try:
+                script_path = self.resource_finder.get_expanded_path(['post_processing_scripts', post_processing_script])
+                self.info_print(f"Running post processing script {post_processing_script}: {script_path}")
+                output = subprocess.check_output([script_path, "--destination-folder", deploy_dir, "--package-name", robot_name])
+            except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError) as e:
+                self.error_print(e)
+                self.error_print(f"Skipping post processing script {post_processing_script}")
+                pass
 
         return robot_name
 

--- a/src/modular/URDF_writer.py
+++ b/src/modular/URDF_writer.py
@@ -1231,6 +1231,12 @@ class UrdfWriter:
         else:
             print(args)
 
+    def error_print(self, *args):
+        if isinstance(self.logger, logging.Logger):
+            self.logger.error(' '.join(str(a) for a in args))
+        else:
+            print(args)
+
     @staticmethod
     def find_module_from_id(module_id, modules):
         """Given the module id find the corresponding dictionary entry and return it"""

--- a/src/modular/config_file.yaml
+++ b/src/modular/config_file.yaml
@@ -9,4 +9,4 @@ external_resources:
 modularbot_path: 'modular_data/ModularBot'
 deploy_dir: '~/src/fhi_ws/src'
 post_processing_scripts: 
-  - '$(rospack find fhi_xbot_plugins)/scripts/post_generation.sh'
+  fhi_post_generation_script: '$(rospack find fhi_xbot_plugins)/scripts/post_generation.sh'

--- a/src/modular/config_file.yaml
+++ b/src/modular/config_file.yaml
@@ -8,3 +8,5 @@ external_resources:
   # whatever_resources_path: None
 modularbot_path: 'modular_data/ModularBot'
 deploy_dir: '~/src/fhi_ws/src'
+post_processing_scripts: 
+  - '$(rospack find fhi_xbot_plugins)/scripts/post_generation.sh'

--- a/src/modular/config_file.yaml
+++ b/src/modular/config_file.yaml
@@ -9,4 +9,6 @@ external_resources:
 modularbot_path: 'modular_data/ModularBot'
 deploy_dir: '~/src/fhi_ws/src'
 post_processing_scripts: 
-  fhi_post_generation_script: '$(rospack find fhi_xbot_plugins)/scripts/post_generation.sh'
+  fhi_post_generation_script: 
+    file: '$(rospack find fhi_xbot_plugins)/scripts/post_generation.sh'
+    required: True

--- a/src/modular/utils.py
+++ b/src/modular/utils.py
@@ -9,6 +9,17 @@ class ResourceFinder:
     def __init__(self, config_file='config_file.yaml'):
         self.cfg = self.get_yaml(config_file)
 
+        self.resources_paths = self.get_all_resources_paths()
+
+    def get_all_resources_paths(self):
+        resources_paths = []
+        # Add internal resources path. By default the path to the resources is at cfg['resources_path']
+        resources_paths.append(['resources_path'])
+        # Add external resources paths. The paths are mapped at cfg['external_resources']
+        for path in self.nested_access(['external_resources']):
+            resources_paths.append(['external_resources', path])
+        return resources_paths
+
     def nested_access(self, keylist):
         val = dict(self.cfg)
         for key in keylist:
@@ -132,9 +143,8 @@ class ResourceFinder:
         return yaml_dict
     
 class ModularResourcesManager:
-    def __init__(self, resource_finder, resources_paths):
+    def __init__(self, resource_finder):
         self.resource_finder = resource_finder
-        self.resources_paths = resources_paths
 
         self.available_modules_dict = {}
         self.available_modules_headers = []
@@ -163,7 +173,7 @@ class ModularResourcesManager:
         return listdir
     
     def init_available_modules(self):
-        for res_path in self.resources_paths:
+        for res_path in self.resource_finder.resources_paths:
             resource_names_list = ['yaml/' + el for el in self.expand_listdir('yaml', res_path)]
             resource_names_list += ['json/' + el for el in self.expand_listdir('json', res_path)]
             for res_name in resource_names_list:
@@ -178,12 +188,12 @@ class ModularResourcesManager:
                     self.available_modules_headers.append(res_dict['header'])
 
     def init_available_families(self):
-        for res_path in self.resources_paths:
+        for res_path in self.resource_finder.resources_paths:
             if self.resource_finder.resource_exists('families.yaml', res_path):
                 self.available_families += (self.resource_finder.get_yaml('families.yaml', res_path)['families'])
 
     def init_available_addons(self):
-        for res_path in self.resources_paths:
+        for res_path in self.resource_finder.resources_paths:
             resource_names_list = ['module_addons/yaml/' + el for el in self.expand_listdir('module_addons/yaml', res_path)]
             resource_names_list += ['module_addons/json/' + el for el in self.expand_listdir('module_addons/json', res_path)]
             for res_name in resource_names_list:

--- a/src/modular/utils.py
+++ b/src/modular/utils.py
@@ -5,12 +5,15 @@ import subprocess
 import io
 import json
 import re
+import logging
 
 class ResourceFinder:
     def __init__(self, config_file='config_file.yaml'):
         self.cfg = self.get_yaml(config_file)
 
         self.resources_paths = self.get_all_resources_paths()
+
+        self.logger = logging.getLogger('ResourceFinder')
 
     def get_all_resources_paths(self):
         resources_paths = []
@@ -42,8 +45,9 @@ class ResourceFinder:
             # The dollar sign is used to execute a command and get the output. What is inside the parenthesis is substituted with the output of the command: $(cmd) -> output of cmd
             expanded_path = re.sub(r"\$\(([^\)]+)\)", path_substitution, expanded_path)
         except (subprocess.CalledProcessError, TypeError):
-            msg = 'Executing ' + expanded_path + ' resulted in an error. Path substitution cannot be completed. Are the required environment variables set?'
-            raise RuntimeError(msg)
+            self.logger.warn('Executing ' + expanded_path + ' resulted in an error. Path substitution cannot be completed. Are the required environment variables set?')
+            pass
+            # raise RuntimeError(msg)
             
         return expanded_path
 

--- a/src/modular/web/RobotDesignStudio.py
+++ b/src/modular/web/RobotDesignStudio.py
@@ -698,7 +698,7 @@ def requestURDF():
 #     return send_from_directory(app.static_folder, path)
 
 
-# upload on the server the /modular_resources folder.
+# upload on the server the /modular_resources folder and the ones under cfg['esternal_resources']
 # This is needed to load the meshes of the modules (withot the need to put them in the /static folder)
 @app.route(f'{api_base_route}/resources/meshes/<path:path>', methods=['GET'])
 @app.route('/modular_resources/<path:path>')
@@ -707,16 +707,9 @@ def send_file(path):
     writer = get_writer()
 
     resources_paths = []
-    resources_paths += [writer.resource_finder.find_resource_absolute_path('', ['resources_path'])]
+    for res_path in writer.resource_finder.resources_paths:
+        resources_paths += [writer.resource_finder.find_resource_absolute_path('', res_path)]
 
-    # upload also external resources (concert_resources, etc.)
-    external_paths_dict = writer.resource_finder.nested_access(['external_resources'])
-    external_paths = [ writer.resource_finder.get_expanded_path(['external_resources', p]) for p in external_paths_dict]
-    resources_paths += external_paths
-
-    # if isinstance(resources_path, str):
-    #     return send_from_directory(resources_path, path)
-    # else:
     for res_path in resources_paths:
         try:
             return send_from_directory(res_path, path)

--- a/src/modular/web/RobotDesignStudio.py
+++ b/src/modular/web/RobotDesignStudio.py
@@ -14,6 +14,7 @@ import logging
 import sys
 from importlib import reload, util
 from configparser import ConfigParser, ExtendedInterpolation
+import re
 
 import numpy as np
 
@@ -658,15 +659,10 @@ def getURDF():
         urdf_string = writer.urdf_string
 
         # replace path for remote access of STL meshes that will be served with '/meshes/<path:path>' route
-        # urdf= urdf_string.replace('package://modular/src/modular/web/static/models/modular/,'package://')
-        urdf= urdf_string\
-                .replace('package://modular_resources',f'package:/{api_base_route}/resources/meshes')\
-                .replace('package://concert_resources',f'package:/{api_base_route}/resources/meshes')\
-                .replace('package://fhi_resources',f'package:/{api_base_route}/resources/meshes')
-
+        frontend_urdf_string = re.sub(r"(package:/)(/[^/]+)(/.*)", fr"\1{api_base_route}/resources/meshes\3", urdf_string)
 
         return  Response(
-            response=urdf,
+            response=frontend_urdf_string,
             status=200,
             mimetype='application/xml'
         )


### PR DESCRIPTION
Hi,

I would like to introduce the possibility to call bash script after robot deploy. 

The first idea that came to my mind is to add a `post_processing_scripts` key to the `config_file.yaml` that is a list of scripts to run after robot deploy. As it can be noticed from the modifications done to `URDF_writer.py` the script will have a common argument interface:
- destination-folder: as your `deploy.sh` script
- package name: name of the generated `modularbot` package

What do you think? Alternatives or improvements are welcome.

Thanks,
Marco